### PR TITLE
build: add precedence for `is` and `is not` operators

### DIFF
--- a/build/print.go
+++ b/build/print.go
@@ -356,6 +356,8 @@ var opPrec = map[string]int{
 	"and":    precAnd,
 	"in":     precCmp,
 	"not in": precCmp,
+	"is":     precCmp,
+	"is not": precCmp,
 	"<":      precCmp,
 	">":      precCmp,
 	"==":     precCmp,


### PR DESCRIPTION
`is` and `is not` have their own `BinaryExpr`s emitted by the parser, but these expressions have no operator precedence of their own, so they are automatically given the highest precedence (`precType`). This causes the formatter to surround them with unnecessary parentheses whenever they are used on the right-hand side of expressions above comparators (`precCmp`) in the order of precedence: assignment, `if`-`else` and `and`/`or`.

Assign the same precedence as other comparators to `is` and `is not` to prevent unnecessary parentheses from being generated by the formatter.