### PR TITLE
tables: only increase sort priority of `tag` parameter for built-ins

### DIFF
--- a/tables/tables.go
+++ b/tables/tables.go
@@ -169,7 +169,8 @@ var NamePriority = map[string]int{
 	"gwt_name":          -98,
 	"package_name":      -97,
 	"visible_node_name": -96, // for boq_initial_css_modules and boq_jswire_test_suite
-	"tag":               -95,
+	"build_rule.tag":    -95,
+	"filegroup.tag":     -95,
 	"size":              -94,
 	"timeout":           -93,
 	"testonly":          -92,


### PR DESCRIPTION
Turns out `tag` is quite a common parameter name for custom build rules. We only want it to sort below `name` in cases where the parameter's value is actually part of the target name, i.e. for the Please built-ins `build_rule` and `filegroup`. In all other cases, it should sort alphabetically with the unprioritised parameters.