### PR TITLE
Enable ShortenAbsoluteLabelsToRelative flag

### DIFF
--- a/tables/tables.go
+++ b/tables/tables.go
@@ -196,7 +196,7 @@ var NamePriority = map[string]int{
 
 var StripLabelLeadingSlashes = false
 
-var ShortenAbsoluteLabelsToRelative = false
+var ShortenAbsoluteLabelsToRelative = true
 
 // AndroidNativeRules lists all Android rules that are being migrated from Native to Starlark.
 var AndroidNativeRules = []string{


### PR DESCRIPTION
This will ensure that absolute labels to package-local targets (e.g. //a/b/c:d) are transformed into local labels (e.g. :d) by the please format command.

The aim of this change is ultimately to address https://github.com/thought-machine/please/issues/3471

I have tested the change by adding a test case to github.com/thought-machine which tests the scenario described in the issue. I will raise a a PR with this test case when bumping the version of github.com/thought-machine/please-build/buildtools used by github.com/thought-machine/please.